### PR TITLE
remove markdown check links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,11 +65,3 @@ jobs:
           version: v1.40
           args: --timeout 5m0s
 
-  link-markdown:
-    name: Lint makrdown
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
-      with:
-        config-file: 'mlc_config.json'


### PR DESCRIPTION
This changes are removed because in the .github repository this action were set.