### PR TITLE
Format adr-002 as a DID Method spec

### DIFF
--- a/architecture/adr-list/adr-002-cheqd-did-method.md
+++ b/architecture/adr-list/adr-002-cheqd-did-method.md
@@ -285,7 +285,11 @@ For Example:
 }
 ```
 
+TODO: describe the resolution process
+
 ##### Deactivate DID
+
+TODO: describe the deactivation process
 
 #### `SCHEMA`
 
@@ -424,7 +428,11 @@ Schema Entity URL: `did:cheqd:N22KY2Dyvmuu2PyyqSFKue/credDef`
 
 ### Security Considerations
 
+TODO: add security considerations
+
 ### Privacy Considerations
+
+TODO: add privacy considerations
 
 ### Rationale and Alternatives
 


### PR DESCRIPTION
This PR restructures the cheqd DID Method proposed in PR #143 (adr-002) as a DID Method Specification.

It makes only minimal changes to the text, but the restructuring makes clear that additional work is needed (e.g., sections without content, better examples)

FYI, this PR modifies the source branch of PR #143, not main.