### PR TITLE
Bump versions in ibc-rs test

### DIFF
--- a/tests/ibc-defi/cheqd/cheqd.Dockerfile
+++ b/tests/ibc-defi/cheqd/cheqd.Dockerfile
@@ -19,7 +19,7 @@ RUN wget -qO- https://github.com/tendermint/starport/releases/download/v0.17.3/s
 # App
 WORKDIR /app
 
-RUN git clone --depth 1 --branch v0.2.3 https://github.com/cheqd/cheqd-node
+RUN git clone --depth 1 --branch v0.3.1 https://github.com/cheqd/cheqd-node
 
 WORKDIR /app/cheqd-node
 

--- a/tests/ibc-defi/cheqd/cheqd_init.sh
+++ b/tests/ibc-defi/cheqd/cheqd_init.sh
@@ -17,7 +17,7 @@ cheqd-noded init node0 --chain-id $CHAIN_ID
 NODE_0_VAL_PUBKEY=$(cheqd-noded tendermint show-validator)
 
 # User
-cheqd-noded keys add cheqd-user
+cheqd-noded keys add cheqd-user --keyring-backend test
 
 # Config
 sed -i $sed_extension 's|minimum-gas-prices = ""|minimum-gas-prices = "25ncheq"|g' "$HOME/.cheqdnode/config/app.toml"
@@ -27,8 +27,8 @@ sed -i $sed_extension 's|laddr = "tcp://127.0.0.1:26657"|laddr = "tcp://0.0.0.0:
 GENESIS="$HOME/.cheqdnode/config/genesis.json"
 sed -i $sed_extension 's/"stake"/"ncheq"/' $GENESIS
 
-cheqd-noded add-genesis-account cheqd-user 1000000000000000000ncheq
-cheqd-noded gentx cheqd-user 10000000000000000ncheq --chain-id $CHAIN_ID --pubkey "$NODE_0_VAL_PUBKEY"
+cheqd-noded add-genesis-account cheqd-user 1000000000000000000ncheq --keyring-backend test
+cheqd-noded gentx cheqd-user 10000000000000000ncheq --chain-id $CHAIN_ID --pubkey "$NODE_0_VAL_PUBKEY" --keyring-backend test
 
 cheqd-noded collect-gentxs
 cheqd-noded validate-genesis

--- a/tests/ibc-defi/hermes/config.toml
+++ b/tests/ibc-defi/hermes/config.toml
@@ -2,10 +2,26 @@
 # client_id, connection_id, channel_id and port_id
 
 [global]
-strategy = 'packets'
-filter = false
 log_level = 'info'
-clear_packets_interval = 100
+
+[mode]
+
+[mode.clients]
+enabled = true
+refresh = true
+misbehaviour = true
+
+[mode.connections]
+enabled = false
+
+[mode.channels]
+enabled = false
+
+[mode.packets]
+enabled = true
+clear_interval = 100
+clear_on_start = true
+filter = false
 tx_confirmation = true
 
 [rest]

--- a/tests/ibc-defi/hermes/hermes.Dockerfile
+++ b/tests/ibc-defi/hermes/hermes.Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 
 WORKDIR /app
 
-RUN git clone --depth 1 --branch v0.7.3 https://github.com/informalsystems/ibc-rs
+RUN git clone --depth 1 --branch v0.9.0 https://github.com/informalsystems/ibc-rs
 
 WORKDIR /app/ibc-rs
 

--- a/tests/ibc-defi/osmosis/osmosis.Dockerfile
+++ b/tests/ibc-defi/osmosis/osmosis.Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 # App
 WORKDIR /app
 
-RUN git clone --depth 1 --branch v4.0.0 https://github.com/osmosis-labs/osmosis
+RUN git clone --depth 1 --branch v4.2.0 https://github.com/osmosis-labs/osmosis
 
 WORKDIR /app/osmosis
 


### PR DESCRIPTION
- cheqd: v0.2.3 -> v0.3.1
- Hermes: v0.7.3 -> v0.9.0
- Osmosis: v4.0.0 -> v4.2.0