### PR TITLE
Dividing images into `cheqd-cli` and `cheqd-node`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   push:
-    tags:
-      - "v*"
+#    tags:
+#      - "v*"
 
 jobs:
   setup-workflow:
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       GITHUB_REPOSITORY_NAME: ${{ steps.cache.outputs.GITHUB_REPOSITORY_NAME }}
+      GITHUB_ORG_NAME: ${{ steps.cache.outputs.GITHUB_ORG_NAME }}
       TAG: ${{ steps.cache.outputs.TAG }}
       VERSION: ${{ steps.cache.outputs.VERSION }}
     steps:
@@ -20,6 +21,9 @@ jobs:
       - name: Set outputs
         id: cache
         run: |
+          # Exposes org_name in lower case. Required by Docker.
+          echo "::set-output name=GITHUB_ORG_NAME::$(echo ${GITHUB_REPOSITORY_OWNER,,})"
+
           # Exposes org_name/repository_name in lower case. Required by Docker.
           echo "::set-output name=GITHUB_REPOSITORY_NAME::$(echo ${GITHUB_REPOSITORY,,})"
 
@@ -125,16 +129,25 @@ jobs:
         with:
           fetch-depth: 0 # FIXME: Starport requires full repository
 
-      - name: Build
-        run: |
-          export CHEQD_NODE_VERSION=local
-          docker compose --env-file docker/persistent-chains/docker-compose.env -f docker/persistent-chains/docker-compose.yml build
-          docker tag ghcr.io/cheqd/cheqd-node:local cheqd-node
+      - name: Build cheqd-cli with 'cheqd-noded' as entrypoint
+        run: docker build --target base -t cheqd-cli -f docker/Dockerfile --build-arg UID=$(id -u) --build-arg GID=$(id -g) .
 
-      - name: Save
+      - name: Build cheqd-node with 'node-start' as entrypoint
+        run: docker build --target node -t cheqd-node -f docker/Dockerfile --build-arg UID=$(id -u) --build-arg GID=$(id -g) .
+
+      - name: Save cheqd-cli
+        run: docker save -o cheqd-cli-image.tar cheqd-cli
+
+      - name: Save cheqd-node
         run: docker save -o cheqd-node-image.tar cheqd-node
 
-      - name: Store artifact
+      - name: Store cheqd-cli artifact 
+        uses: actions/upload-artifact@v2
+        with:
+          name: cheqd-cli-image.tar
+          path: cheqd-cli-image.tar
+      
+      - name: Store cheqd-node artifact 
         uses: actions/upload-artifact@v2
         with:
           name: cheqd-node-image.tar
@@ -151,10 +164,10 @@ jobs:
       - name: Download node image
         uses: actions/download-artifact@v2
         with:
-          name: cheqd-node-image.tar
+          name: cheqd-cli-image.tar
 
       - name: Load node image
-        run: docker load -i cheqd-node-image.tar
+        run: docker load -i cheqd-cli-image.tar
 
       - name: Build
         run: docker build -f tests/networks/docker-localnet/Dockerfile --no-cache -t cheqd-testnet .
@@ -175,6 +188,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_REPOSITORY_NAME: ${{ needs.setup-workflow.outputs.GITHUB_REPOSITORY_NAME }}
+      GITHUB_ORG_NAME: ${{ needs.setup-workflow.outputs.GITHUB_ORG_NAME }}
       TAG: ${{ needs.setup-workflow.outputs.TAG }}
       VERSION: ${{ needs.setup-workflow.outputs.VERSION }}
       PACKAGE_NAME: "cheqd-node"
@@ -183,12 +197,20 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v2
 
-      - name: Download node image
+      - name: Download cheqd-cli image
+        uses: actions/download-artifact@v2
+        with:
+          name: cheqd-cli-image.tar
+
+      - name: Download cheqd-node image
         uses: actions/download-artifact@v2
         with:
           name: cheqd-node-image.tar
 
-      - name: Load node image
+      - name: Load cheqd-cli image
+        run: docker load -i cheqd-cli-image.tar
+
+      - name: Load cheqd-node image
         run: docker load -i cheqd-node-image.tar
 
       - name: Download testnet image
@@ -203,19 +225,27 @@ jobs:
         run: |
           echo ${{ secrets.GH_PAT }} | docker login ghcr.io --username ${{ secrets.GH_USER }} --password-stdin
 
-      - name: Push node image
+      - name: Push cheqd-node image
         run: |
           docker tag cheqd-node ghcr.io/${{ env.GITHUB_REPOSITORY_NAME }}:${{ env.VERSION }}
           docker tag cheqd-node ghcr.io/${{ env.GITHUB_REPOSITORY_NAME }}:latest
-          docker push ghcr.io/${{ env.GITHUB_REPOSITORY_NAME }}:${{ env.VERSION }}
-          docker push ghcr.io/${{ env.GITHUB_REPOSITORY_NAME }}:latest
+#          docker push ghcr.io/${{ env.GITHUB_REPOSITORY_NAME }}:${{ env.VERSION }}
+#          docker push ghcr.io/${{ env.GITHUB_REPOSITORY_NAME }}:latest
+
+      
+      - name: Push cheqd-cli image
+        run: |
+          docker tag cheqd-cli ghcr.io/${{ env.GITHUB_ORG_NAME }}/cheqd-cli:${{ env.VERSION }}
+          docker tag cheqd-cli ghcr.io/${{ env.GITHUB_ORG_NAME }}/cheqd-cli:latest
+#          docker push ghcr.io/${{ env.GITHUB_ORG_NAME }}:${{ env.VERSION }}
+#          docker push ghcr.io/${{ env.GITHUB_ORG_NAME }}:latest
 
       - name: Push testnet image
         run: |
           docker tag cheqd-testnet ghcr.io/${{ github.repository_owner }}/${{ env.TESTNET_IMAGE_NAME }}:${{ env.VERSION }}
           docker tag cheqd-testnet ghcr.io/${{ github.repository_owner }}/${{ env.TESTNET_IMAGE_NAME }}:latest
-          docker push ghcr.io/${{ github.repository_owner }}/${{ env.TESTNET_IMAGE_NAME }}:${{ env.VERSION }}
-          docker push ghcr.io/${{ github.repository_owner }}/${{ env.TESTNET_IMAGE_NAME }}:latest
+#          docker push ghcr.io/${{ github.repository_owner }}/${{ env.TESTNET_IMAGE_NAME }}:${{ env.VERSION }}
+#          docker push ghcr.io/${{ github.repository_owner }}/${{ env.TESTNET_IMAGE_NAME }}:latest
 
       - name: Download deb
         uses: actions/download-artifact@v2
@@ -233,11 +263,11 @@ jobs:
       - name: Make tar archive
         run: tar -zcvf ${{ env.PACKAGE_NAME }}_${{ env.VERSION }}.tar.gz cheqd-noded
 
-      - uses: "marvinpinto/action-automatic-releases@latest"
-        with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "${{ env.TAG }}"
-          prerelease: true
-          files: |
-            ${{ env.PACKAGE_NAME }}_${{ env.VERSION }}_amd64.deb
-            ${{ env.PACKAGE_NAME }}_${{ env.VERSION }}.tar.gz
+#      - uses: "marvinpinto/action-automatic-releases@latest"
+#        with:
+#          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+#          automatic_release_tag: "${{ env.TAG }}"
+#          prerelease: true
+#          files: |
+#            ${{ env.PACKAGE_NAME }}_${{ env.VERSION }}_amd64.deb
+#            ${{ env.PACKAGE_NAME }}_${{ env.VERSION }}.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,8 @@ jobs:
       GITHUB_REPOSITORY_NAME: ${{ steps.cache.outputs.GITHUB_REPOSITORY_NAME }}
       GITHUB_ORG_NAME: ${{ steps.cache.outputs.GITHUB_ORG_NAME }}
       TAG: ${{ steps.cache.outputs.TAG }}
-      VERSION: ${{ steps.cache.outputs.VERSION }}
+      VERSION: 0.0.1
+      #VERSION: ${{ steps.cache.outputs.VERSION }}
     steps:
       - name: Git checkout
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   push:
-#    tags:
-#      - "v*"
+    tags:
+      - "v*"
 
 jobs:
   setup-workflow:
@@ -13,8 +13,7 @@ jobs:
       GITHUB_REPOSITORY_NAME: ${{ steps.cache.outputs.GITHUB_REPOSITORY_NAME }}
       GITHUB_ORG_NAME: ${{ steps.cache.outputs.GITHUB_ORG_NAME }}
       TAG: ${{ steps.cache.outputs.TAG }}
-      VERSION: 0.0.1
-      #VERSION: ${{ steps.cache.outputs.VERSION }}
+      VERSION: ${{ steps.cache.outputs.VERSION }}
     steps:
       - name: Git checkout
         uses: actions/checkout@v2
@@ -230,23 +229,23 @@ jobs:
         run: |
           docker tag cheqd-node ghcr.io/${{ env.GITHUB_REPOSITORY_NAME }}:${{ env.VERSION }}
           docker tag cheqd-node ghcr.io/${{ env.GITHUB_REPOSITORY_NAME }}:latest
-#          docker push ghcr.io/${{ env.GITHUB_REPOSITORY_NAME }}:${{ env.VERSION }}
-#          docker push ghcr.io/${{ env.GITHUB_REPOSITORY_NAME }}:latest
+          docker push ghcr.io/${{ env.GITHUB_REPOSITORY_NAME }}:${{ env.VERSION }}
+          docker push ghcr.io/${{ env.GITHUB_REPOSITORY_NAME }}:latest
 
       
       - name: Push cheqd-cli image
         run: |
           docker tag cheqd-cli ghcr.io/${{ env.GITHUB_ORG_NAME }}/cheqd-cli:${{ env.VERSION }}
           docker tag cheqd-cli ghcr.io/${{ env.GITHUB_ORG_NAME }}/cheqd-cli:latest
-#          docker push ghcr.io/${{ env.GITHUB_ORG_NAME }}:${{ env.VERSION }}
-#          docker push ghcr.io/${{ env.GITHUB_ORG_NAME }}:latest
+          docker push ghcr.io/${{ env.GITHUB_ORG_NAME }}:${{ env.VERSION }}
+          docker push ghcr.io/${{ env.GITHUB_ORG_NAME }}:latest
 
       - name: Push testnet image
         run: |
           docker tag cheqd-testnet ghcr.io/${{ github.repository_owner }}/${{ env.TESTNET_IMAGE_NAME }}:${{ env.VERSION }}
           docker tag cheqd-testnet ghcr.io/${{ github.repository_owner }}/${{ env.TESTNET_IMAGE_NAME }}:latest
-#          docker push ghcr.io/${{ github.repository_owner }}/${{ env.TESTNET_IMAGE_NAME }}:${{ env.VERSION }}
-#          docker push ghcr.io/${{ github.repository_owner }}/${{ env.TESTNET_IMAGE_NAME }}:latest
+          docker push ghcr.io/${{ github.repository_owner }}/${{ env.TESTNET_IMAGE_NAME }}:${{ env.VERSION }}
+          docker push ghcr.io/${{ github.repository_owner }}/${{ env.TESTNET_IMAGE_NAME }}:latest
 
       - name: Download deb
         uses: actions/download-artifact@v2
@@ -264,11 +263,11 @@ jobs:
       - name: Make tar archive
         run: tar -zcvf ${{ env.PACKAGE_NAME }}_${{ env.VERSION }}.tar.gz cheqd-noded
 
-#      - uses: "marvinpinto/action-automatic-releases@latest"
-#        with:
-#          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-#          automatic_release_tag: "${{ env.TAG }}"
-#          prerelease: true
-#          files: |
-#            ${{ env.PACKAGE_NAME }}_${{ env.VERSION }}_amd64.deb
-#            ${{ env.PACKAGE_NAME }}_${{ env.VERSION }}.tar.gz
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "${{ env.TAG }}"
+          prerelease: true
+          files: |
+            ${{ env.PACKAGE_NAME }}_${{ env.VERSION }}_amd64.deb
+            ${{ env.PACKAGE_NAME }}_${{ env.VERSION }}.tar.gz

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,7 +127,6 @@ jobs:
       - name: Build cheqd-node with 'node-start' as entrypoint
         run: docker build --target node -t cheqd-node -f docker/Dockerfile --build-arg UID=$(id -u) --build-arg GID=$(id -g) .
           
-
       - name: Save cheqd-cli
         run: docker save -o cheqd-cli-image.tar cheqd-cli
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,7 +132,7 @@ jobs:
         run: docker save -o cheqd-cli-image.tar cheqd-cli
 
       - name: Save cheqd-node
-        run: docker save -o cheqd-cli-image.tar cheqd-node
+        run: docker save -o cheqd-node-image.tar cheqd-node
 
       - name: Store cheqd-cli artifact 
         uses: actions/upload-artifact@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,16 +121,26 @@ jobs:
         with:
           fetch-depth: 0 # FIXME: Starport requires full repository
 
-      - name: Build
-        run: |
-          export CHEQD_NODE_VERSION=local
-          docker compose --env-file docker/persistent-chains/docker-compose.env -f docker/persistent-chains/docker-compose.yml build --build-arg UID=$(id -u) --build-arg GID=$(id -g)
-          docker tag ghcr.io/cheqd/cheqd-node:local cheqd-node
+      - name: Build cheqd-cli with 'cheqd-noded' as entrypoint
+        run: docker build --target base -t cheqd-cli .
 
-      - name: Save
-        run: docker save -o cheqd-node-image.tar cheqd-node
+      - name: Build cheqd-node with 'node-start' as entrypoint
+        run: docker build --target node -t cheqd-node .
+          
 
-      - name: Store artifact
+      - name: Save cheqd-cli
+        run: docker save -o cheqd-cli-image.tar cheqd-cli
+
+      - name: Save cheqd-node
+        run: docker save -o cheqd-cli-image.tar cheqd-node
+
+      - name: Store cheqd-cli artifact 
+        uses: actions/upload-artifact@v2
+        with:
+          name: cheqd-cli-image.tar
+          path: cheqd-cli-image.tar
+      
+      - name: Store cheqd-node artifact 
         uses: actions/upload-artifact@v2
         with:
           name: cheqd-node-image.tar
@@ -147,10 +157,10 @@ jobs:
       - name: Download node image
         uses: actions/download-artifact@v2
         with:
-          name: cheqd-node-image.tar
+          name: cheqd-cli-image.tar
 
       - name: Load node image
-        run: docker load -i cheqd-node-image.tar
+        run: docker load -i cheqd-cli-image.tar
 
       - name: Build
         run: docker build -f tests/networks/docker-localnet/Dockerfile --no-cache -t cheqd-testnet .
@@ -180,10 +190,10 @@ jobs:
       - name: Download node image
         uses: actions/download-artifact@v2
         with:
-          name: cheqd-node-image.tar
+          name: cheqd-cli-image.tar
 
       - name: Load node image
-        run: docker load -i cheqd-node-image.tar
+        run: docker load -i cheqd-cli-image.tar
 
       - name: Check out
         uses: actions/checkout@v2
@@ -237,10 +247,10 @@ jobs:
       - name: Download node image
         uses: actions/download-artifact@v2
         with:
-          name: cheqd-node-image.tar
+          name: cheqd-cli-image.tar
 
       - name: Load node image
-        run: docker load -i cheqd-node-image.tar
+        run: docker load -i cheqd-cli-image.tar
 
       - uses: actions/checkout@v2
 
@@ -317,10 +327,10 @@ jobs:
       - name: Download node image
         uses: actions/download-artifact@v2
         with:
-          name: cheqd-node-image.tar
+          name: cheqd-cli-image.tar
 
       - name: Load node image
-        run: docker load -i cheqd-node-image.tar
+        run: docker load -i cheqd-cli-image.tar
 
       - name: Chown for current user
         run: sudo chown $USER:$USER .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,10 +122,10 @@ jobs:
           fetch-depth: 0 # FIXME: Starport requires full repository
 
       - name: Build cheqd-cli with 'cheqd-noded' as entrypoint
-        run: docker build --target base -t cheqd-cli -f docker/Dockerfile .
+        run: docker build --target base -t cheqd-cli -f docker/Dockerfile --build-arg UID=$(id -u) --build-arg GID=$(id -g) .
 
       - name: Build cheqd-node with 'node-start' as entrypoint
-        run: docker build --target node -t cheqd-node -f docker/Dockerfile .
+        run: docker build --target node -t cheqd-node -f docker/Dockerfile --build-arg UID=$(id -u) --build-arg GID=$(id -g) .
           
 
       - name: Save cheqd-cli

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,10 +122,10 @@ jobs:
           fetch-depth: 0 # FIXME: Starport requires full repository
 
       - name: Build cheqd-cli with 'cheqd-noded' as entrypoint
-        run: docker build --target base -t cheqd-cli .
+        run: docker build --target base -t cheqd-cli -f docker/Dockerfile .
 
       - name: Build cheqd-node with 'node-start' as entrypoint
-        run: docker build --target node -t cheqd-node .
+        run: docker build --target node -t cheqd-node -f docker/Dockerfile .
           
 
       - name: Save cheqd-cli

--- a/tests/networks/docker-compose-localnet/.env
+++ b/tests/networks/docker-compose-localnet/.env
@@ -1,3 +1,3 @@
 CHEQD_VERSION="latest"
-CHEQD_IMAGE_NAME="cheqd-node"
+CHEQD_IMAGE_NAME="cheqd-cli"
 MOUNT_POINT="."

--- a/tests/networks/docker-compose-localnet/docker-compose.yml
+++ b/tests/networks/docker-compose-localnet/docker-compose.yml
@@ -8,7 +8,6 @@ services:
       - "26657:26657" # rpc
     volumes:
       - "${MOUNT_POINT}/node_configs/node0:/cheqd"
-    entrypoint: cheqd-noded
     user: cheqd
     environment:
       - HOME=/cheqd
@@ -21,7 +20,6 @@ services:
       - "26660:26657" # rpc
     volumes:
       - "${MOUNT_POINT}/node_configs/node1:/cheqd"
-    entrypoint: cheqd-noded
     user: cheqd
     environment:
       - HOME=/cheqd
@@ -34,7 +32,6 @@ services:
       - "26663:26657" # rpc
     volumes:
       - "${MOUNT_POINT}/node_configs/node2:/cheqd"
-    entrypoint: cheqd-noded
     user: cheqd
     environment:
       - HOME=/cheqd
@@ -47,7 +44,6 @@ services:
       - "26666:26657" # rpc
     volumes:
       - "${MOUNT_POINT}/node_configs/node3:/cheqd"
-    entrypoint: cheqd-noded
     user: cheqd
     environment:
       - HOME=/cheqd
@@ -60,7 +56,6 @@ services:
       - "26669:26657" # rpc
     volumes:
       - "${MOUNT_POINT}/node_configs/observer0:/cheqd"
-    entrypoint: cheqd-noded
     user: cheqd
     environment:
       - HOME=/cheqd
@@ -73,7 +68,6 @@ services:
       - "26672:26657" # rpc
     volumes:
       - "${MOUNT_POINT}/node_configs/observer1:/cheqd"
-    entrypoint: cheqd-noded
     user: cheqd
     environment:
       - HOME=/cheqd

--- a/tests/networks/docker-compose-localnet/gen-node-configs.sh
+++ b/tests/networks/docker-compose-localnet/gen-node-configs.sh
@@ -6,6 +6,8 @@ set -euox pipefail
 
 # sed in macos requires extra argument
 
+CHEQD_NODE_IMAGE=cheqd-cli
+
 sed_extension=''
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     sed_extension=''
@@ -18,8 +20,7 @@ fi
 cheqd_noded_docker() {
   docker run --rm \
     -v "$(pwd)":"/home/cheqd" \
-    --entrypoint "cheqd-noded" \
-    cheqd-node "$@"
+    $CHEQD_NODE_IMAGE "$@"
 }
 
 

--- a/tests/networks/docker-compose-localnet/run-docker.sh
+++ b/tests/networks/docker-compose-localnet/run-docker.sh
@@ -6,11 +6,12 @@ set -euox pipefail
 
 # cheqd_noded docker wrapper
 
+CHEQD_NODE_IMAGE=cheqd-cli
+
 cheqd_noded_docker() {
   docker run --rm \
     -v "$(pwd)":"/home/cheqd" \
-    --entrypoint "cheqd-noded" \
-    cheqd-node "$@"
+    $CHEQD_NODE_IMAGE "$@"
 }
 
 # sed in macos requires extra argument

--- a/tests/networks/docker-localnet/Dockerfile
+++ b/tests/networks/docker-localnet/Dockerfile
@@ -1,4 +1,4 @@
-FROM cheqd-node
+FROM cheqd-cli
 
 USER root
 

--- a/tests/upgrade/common.sh
+++ b/tests/upgrade/common.sh
@@ -4,7 +4,7 @@ set -euox pipefail
 
 DOCKER_COMPOSE_DIR="../networks/docker-compose-localnet"
 CHEQD_IMAGE_FROM="ghcr.io/cheqd/cheqd-node:0.4.0"
-CHEQD_IMAGE_TO="cheqd-node"
+CHEQD_IMAGE_TO="cheqd-cli"
 CHEQD_VERSION_TO=`echo $(git describe --always --tag --match "v*") | sed 's/^v//'`
 UPGRADE_NAME="v0.4"
 VOTING_PERIOD=30

--- a/tests/upgrade/gen_node_configs.sh
+++ b/tests/upgrade/gen_node_configs.sh
@@ -27,15 +27,6 @@ edit_genesis () {
     jq "${PARAMETER_NAME} = \"${VALUE}\"" $GENESIS_PATH > /tmp/1 && mv /tmp/1 $GENESIS_PATH
 }
 
-# We use local copy of this function because of using -u root for allowing files creation inside the
-cheqd_noded_docker() {
-  docker run --rm \
-    -v "$(pwd)":"/cheqd" \
-    --network host \
-    --entrypoint "cheqd-noded" \
-    -u root \
-    ${CHEQD_IMAGE_FROM} "$@" --home /cheqd/.cheqdnode
-}
 
 VALIDATORS_COUNT="4"
 OBSERVERS_COUNT="2"

--- a/tests/upgrade/upgrade_and_check.sh
+++ b/tests/upgrade/upgrade_and_check.sh
@@ -21,7 +21,7 @@ docker_compose_up "$CHEQD_IMAGE_TO" $(pwd)
 # Wait for upgrade height
 bash ../networks/tools/wait-for-chain.sh $(echo $UPGRADE_HEIGHT+2 | bc)
 
-CURRENT_VERSION=$(docker run --entrypoint cheqd-noded cheqd-node version 2>&1)
+CURRENT_VERSION=$(docker run --entrypoint cheqd-noded $CHEQD_IMAGE_TO version 2>&1)
 
 if [ $CURRENT_VERSION != $CHEQD_VERSION_TO ] ; then
      echo "Upgrade to version $CHEQD_VERSION_TO was not successful"


### PR DESCRIPTION
This PR is about creating 2 images instead of 1.
- `cheqd-cli` with entrypoint cheqd-noded (stage 2 in Dockerfile)
- `cheqd-node` with entrypoint as `node-start` (stage 3 in Dockerfile)