### PR TITLE
fix: Ability to write spaces in the moniker

### DIFF
--- a/installer/installer.py
+++ b/installer/installer.py
@@ -413,7 +413,7 @@ class Installer():
     def post_install(self):
         # Init the node with provided moniker
         if not os.path.exists(os.path.join(self.cheqd_config_dir, 'genesis.json')):
-            self.exec(f"sudo su -c 'cheqd-noded init {self.interviewer.moniker}' {DEFAULT_CHEQD_USER}")
+            self.exec(f"""sudo su -c 'cheqd-noded init "{self.interviewer.moniker}"' {DEFAULT_CHEQD_USER}""")
 
             # Downloading genesis file
             self.exec(f"curl {GENESIS_FILE.format(self.interviewer.chain)} > {os.path.join(self.cheqd_config_dir, 'genesis.json')}")


### PR DESCRIPTION
When calling the "cheqd-noded init" command, the moniker is replaced with the same, enclosed in quotation marks. This allows to write moniker with a space.
