### PR TITLE
ci: Allow changes to be triggered by forks [DEV-1828]

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -9,12 +9,12 @@ jobs:
 
   call-lint:
     name: "Lint"
-    uses: ./.github/workflows/lint.yml
+    uses: cheqd/.github/workflows/lint.yml@develop
 
   call-build:
     name: "Build"
     needs: call-lint
-    uses: ./.github/workflows/build.yml
+    uses: cheqd/.github/workflows/build.yml@develop
     secrets: inherit
   
   # call-test:
@@ -28,5 +28,5 @@ jobs:
     # needs: call-test
     needs: call-build
     if: ${{ github.ref_protected == true }}
-    uses: ./.github/workflows/release.yml
+    uses: cheqd/.github/workflows/release.yml@develop
     secrets: inherit


### PR DESCRIPTION
Currently, any forked branches don't run any workflows except for PR Lint Check. This is because their copy of dispatch can't invoke read/write permissions.