### PR TITLE
chore: Bump to Cosmovisor v1.4

### DIFF
--- a/installer/installer.py
+++ b/installer/installer.py
@@ -36,8 +36,10 @@ PRINT_PREFIX = "********* "
 ###############################################################
 ###     				Cosmovisor Config      				###
 ###############################################################
-COSMOVISOR_BINARY_URL = "https://github.com/cosmos/cosmos-sdk/releases/download/cosmovisor%2Fv1.1.0/cosmovisor-v1.1.0-linux-amd64.tar.gz"
+DEFAULT_LATEST_COSMOVISOR_VERSION = "v1.3.0"
+COSMOVISOR_BINARY_URL = f"https://github.com/cosmos/cosmos-sdk/releases/download/cosmovisor%2F{DEFAULT_LATEST_COSMOVISOR_VERSION}/cosmovisor-{DEFAULT_LATEST_COSMOVISOR_VERSION}-linux-amd64.tar.gz"
 DEFAULT_USE_COSMOVISOR = "yes"
+DEFAULT_BUMP_COSMOVISOR = "yes"
 
 ###############################################################
 ###     				Systemd Config      				###
@@ -415,6 +417,10 @@ class Installer():
         if self.interviewer.is_cosmo_needed:
             self.log("Setting up Cosmovisor")
             self.setup_cosmovisor()
+        
+        if self.interviewer.is_cosmovisor_bump_needed:
+            self.log(f"Bumping Cosmovisor to {DEFAULT_LATEST_COSMOVISOR_VERSION}")
+            self.bump_cosmovisor()
 
         if not self.interviewer.is_cosmo_needed:
             self.log(f"Moving binary from {self.binary_path} to {DEFAULT_INSTALL_PATH}")
@@ -578,6 +584,51 @@ class Installer():
             self.exec(f"chown -R {DEFAULT_CHEQD_USER}:{DEFAULT_CHEQD_USER} {self.cosmovisor_root_dir}")
         except:
             failure_exit(f"Failed to setup Cosmovisor")
+    # This method is exact same with setup_cosmovisor() except it doesn't create existing directories. We could do this inside same method but could lead to coupling.
+    def bump_cosmovisor(self):
+        try:
+            fname= os.path.basename(COSMOVISOR_BINARY_URL)
+            self.exec(f"wget -c {COSMOVISOR_BINARY_URL}")
+            self.exec(f"tar -xzf {fname}")
+            self.remove_safe(fname)
+            
+            # Remove cosmovisor artifacts...
+            self.remove_safe("CHANGELOG.md")
+            self.remove_safe("README.md")
+            self.remove_safe("LICENSE")
+
+            if not os.path.exists(os.path.join(DEFAULT_INSTALL_PATH, DEFAULT_COSMOVISOR_BINARY_NAME)):
+                self.log(f"Moving Cosmovisor binary to installation directory")
+                shutil.move("./cosmovisor", DEFAULT_INSTALL_PATH)
+
+            if not os.path.exists(os.path.join(self.cosmovisor_root_dir, "current")):
+                self.log(f"Creating symlink for current Cosmovisor version")
+                os.symlink(os.path.join(self.cosmovisor_root_dir, "genesis"),
+                        os.path.join(self.cosmovisor_root_dir, "current"))
+
+            self.log(f"Moving binary from {self.binary_path} to {self.cosmovisor_cheqd_bin_path}")
+            self.exec("sudo mv {} {}".format(self.binary_path, self.cosmovisor_cheqd_bin_path))
+            self.exec("sudo chown {} {}".format(f'{DEFAULT_CHEQD_USER}:{DEFAULT_CHEQD_USER}', f'{DEFAULT_INSTALL_PATH}/{DEFAULT_COSMOVISOR_BINARY_NAME}'))
+            self.exec("sudo chmod +x {}".format(f'{DEFAULT_INSTALL_PATH}/{DEFAULT_COSMOVISOR_BINARY_NAME}'))
+
+            if not os.path.exists(os.path.join(DEFAULT_INSTALL_PATH, DEFAULT_BINARY_NAME)):
+                self.log(f"Creating symlink to {self.cosmovisor_cheqd_bin_path}")
+                os.symlink(self.cosmovisor_cheqd_bin_path,
+                        os.path.join(DEFAULT_INSTALL_PATH, DEFAULT_BINARY_NAME))
+
+            if self.interviewer.is_upgrade and \
+                os.path.exists(os.path.join(self.cheqd_data_dir, "upgrade-info.json")):
+
+                self.log(f"Copying upgrade-info.json file to cosmovisor/current/")
+                shutil.copy(os.path.join(self.cheqd_data_dir, "upgrade-info.json"),
+                            os.path.join(self.cosmovisor_root_dir, "current"))
+                self.log(f"Changing owner to {DEFAULT_CHEQD_USER} user")
+                self.exec(f"chown -R {DEFAULT_CHEQD_USER}:{DEFAULT_CHEQD_USER} {self.cosmovisor_root_dir}")
+        
+            self.log(f"Changing directory ownership for Cosmovisor to {DEFAULT_CHEQD_USER} user")
+            self.exec(f"chown -R {DEFAULT_CHEQD_USER}:{DEFAULT_CHEQD_USER} {self.cosmovisor_root_dir}")
+        except:
+            failure_exit(f"Failed to setup Cosmovisor")
 
     def compare_checksum(self, file_path):
         # Set URL for correct checksum file for snapshot
@@ -665,6 +716,7 @@ class Interviewer:
         self._home_dir = home_dir
         self._is_upgrade = False
         self._is_cosmo_needed = True
+        self._is_cosmovisor_bump_needed = True
         self._init_from_snapshot = False
         self._release = None
         self._chain = chain
@@ -728,6 +780,10 @@ class Interviewer:
     @property
     def is_cosmo_needed(self) -> bool:
         return self._is_cosmo_needed
+    
+    @property
+    def is_cosmovisor_bump_needed(self) -> bool:
+        return self._is_cosmovisor_bump_needed
 
     @property
     def init_from_snapshot(self) -> bool:
@@ -808,6 +864,10 @@ class Interviewer:
     @is_cosmo_needed.setter
     def is_cosmo_needed(self, icn):
         self._is_cosmo_needed = icn
+    
+    @is_cosmovisor_bump_needed.setter
+    def is_cosmovisor_bump_needed(self, icn):
+        self._is_cosmovisor_bump_needed = icn
 
     @init_from_snapshot.setter
     def init_from_snapshot(self, ifs):
@@ -994,6 +1054,15 @@ class Interviewer:
             self.is_cosmo_needed = False
         else:
             failure_exit(f"Invalid input provided during installation.")
+    
+    def ask_for_cosmovisor_bump(self):
+        answer = self.ask(f"Install {DEFAULT_LATEST_COSMOVISOR_VERSION} cosmovisor? (yes/no)", default=DEFAULT_BUMP_COSMOVISOR)
+        if answer.lower().startswith("y"):
+            self.is_cosmovisor_bump_needed = True
+        elif answer.lower().startswith("n"):
+            self.is_cosmovisor_bump_needed = False
+        else:
+            failure_exit(f"Invalid input provided during installation.")
 
     def ask_for_init_from_snapshot(self):
         answer = self.ask(
@@ -1114,7 +1183,11 @@ if __name__ == '__main__':
 
     # Steps to execute if upgrading existing node
     def upgrade_steps():
-        interviewer.ask_for_cosmovisor()
+        # if cosmovisor is not installed 
+        if not os.path.exists(os.path.join(DEFAULT_INSTALL_PATH, DEFAULT_COSMOVISOR_BINARY_NAME)):
+            interviewer.ask_for_cosmovisor()
+        else:
+            interviewer.ask_for_cosmovisor_bump()
         if interviewer.is_systemd_config_exists():
             interviewer.ask_for_rewrite_systemd()
         if os.path.exists(DEFAULT_RSYSLOG_FILE):


### PR DESCRIPTION
This PR bumps Cosmovisor to `v1.3.0` There are not differences between `v1.3.0` and `v1.4.0` except for package name rename. You can see more [here](https://github.com/cosmos/cosmos-sdk/releases?q=cosmovisor&expanded=true). Also, v1.4 doesn't have `tar.gz` file inside the assets. 

