### PR TITLE
test: Add the ability to read env variables

### DIFF
--- a/tests/upgrade/integration/cli/config.go
+++ b/tests/upgrade/integration/cli/config.go
@@ -48,4 +48,6 @@ var (
 		"--chain-id", integrationnetwork.CHAIN_ID,
 		"--output", OUTPUT_FORMAT,
 	}
+	// TODO: UGLY THING, needs to be refactored
+	RUN_INSIDE_DOCKER = true
 )

--- a/tests/upgrade/integration/cli/docker.go
+++ b/tests/upgrade/integration/cli/docker.go
@@ -2,8 +2,10 @@ package cli
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
@@ -54,6 +56,9 @@ var (
 func LocalnetExec(envArgs []string, args ...string) (string, error) {
 	args = append(append([]string{DOCKER_COMPOSE}, envArgs...), args...)
 	cmd := exec.Command(DOCKER, args...)
+	if os.Getenv("DEBUG") != "true" {
+		fmt.Println("DEBUG: Command for run: ", strings.Join(cmd.Args, " "))
+	}
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return string(out), sdkerrors.Wrap(err, string(out))

--- a/tests/upgrade/integration/cli/exec.go
+++ b/tests/upgrade/integration/cli/exec.go
@@ -2,7 +2,10 @@ package cli
 
 import (
 	"os"
+	"fmt"
+	"strings"
 	"os/exec"
+	"path/filepath"
 
 	integrationcli "github.com/cheqd/cheqd-node/tests/integration/cli"
 	"github.com/cosmos/cosmos-sdk/types/errors"
@@ -14,12 +17,23 @@ func Exec(args ...string) (string, error) {
 
 func ExecDirect(args ...string) (string, error) {
 	cmd := exec.Command(args[0], args[1:]...)
+	if os.Getenv("DEBUG") == "true" {
+		fmt.Println("DEBUG: Command for run: ", strings.Join(cmd.Args, " "))
+	}
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", errors.Wrap(err, string(out))
 	}
 
 	return string(out), err
+}
+
+func ExecDirectWithHome(operator string, args ...string) (string, error) {
+	var node_home = os.Getenv("CHEQD_NODE_HOME")
+	if node_home == "" {
+		node_home = filepath.Join("../../../docker/localnet", NETWORK_CONFIG_DIR, operator)
+	}
+	return ExecDirect(append(args, "--home", node_home)...)
 }
 
 func ExecWithEnv(env []string, args ...string) (string, error) {

--- a/tests/upgrade/integration/cli/helpers.go
+++ b/tests/upgrade/integration/cli/helpers.go
@@ -72,7 +72,15 @@ type ValidatorInfo struct {
 }
 
 func GetNodeStatus(container string, binary string) (NodeStatus, error) {
-	out, err := LocalnetExecExec(container, binary, "status")
+	var out string
+	var err error
+	
+	// ToDo: refactor
+	if RUN_INSIDE_DOCKER {
+		out, err = LocalnetExecExec(container, binary, "status")
+	} else {
+		out, err = ExecDirect(binary, "status")
+	}
 	if err != nil {
 		return NodeStatus{}, err
 	}

--- a/tests/upgrade/integration/cli/query.go
+++ b/tests/upgrade/integration/cli/query.go
@@ -26,13 +26,23 @@ func Query(container string, binary string, module, query string, queryArgs ...s
 }
 
 func QueryModuleVersionMap(container string) (upgradetypes.QueryModuleVersionsResponse, error) {
+	var out string
+	var err error
+	
 	fmt.Println("Querying module version map from", container)
 	args := append([]string{
 		CLI_BINARY_NAME,
 		"query", "upgrade", "module_versions",
 	}, QUERY_PARAMS...)
 
-	out, err := LocalnetExecExec(container, args...)
+	// ToDo: refactor
+	if RUN_INSIDE_DOCKER {
+		println("Inside the container")
+		out, err = LocalnetExecExec(container, args...)
+	} else {
+		println("just local run")
+		out, err = ExecDirectWithHome(container, args...)
+	}
 	if err != nil {
 		return upgradetypes.QueryModuleVersionsResponse{}, err
 	}
@@ -50,13 +60,24 @@ func QueryModuleVersionMap(container string) (upgradetypes.QueryModuleVersionsRe
 }
 
 func QueryParams(container, subspace, key string) (paramproposal.ParamChange, error) {
+	var out string
+	var err error
+
 	fmt.Println("Querying params from", container)
 	args := append([]string{
 		CLI_BINARY_NAME,
 		"query", "params", "subspace", subspace, key,
 	}, QUERY_PARAMS...)
 
-	out, err := LocalnetExecExec(container, args...)
+	// ToDo: refactor
+	if RUN_INSIDE_DOCKER {
+		println("Inside the container")
+		out, err = LocalnetExecExec(container, args...)
+	} else {
+		println("just local run")
+		out, err = ExecDirectWithHome(container, args...)
+	}
+
 	if err != nil {
 		return paramproposal.ParamChange{}, err
 	}
@@ -106,13 +127,24 @@ func QueryResourceFeeParams(container, subspace, key string) (resourcetypes.FeeP
 }
 
 func QueryProposalLegacy(container, id string) (govtypesv1beta1.Proposal, error) {
+	var out string
+	var err error
+
 	fmt.Println("Querying proposal from", container)
 	args := append([]string{
 		CLI_BINARY_NAME,
 		"query", "gov", "proposal", id,
 	}, QUERY_PARAMS...)
 
-	out, err := LocalnetExecExec(container, args...)
+	// ToDo: refactor
+	if RUN_INSIDE_DOCKER {
+		println("Inside the container")
+		out, err = LocalnetExecExec(container, args...)
+	} else {
+		println("just local run")
+		out, err = ExecDirectWithHome(container, args...)
+	}
+
 	if err != nil {
 		return govtypesv1beta1.Proposal{}, err
 	}
@@ -129,13 +161,24 @@ func QueryProposalLegacy(container, id string) (govtypesv1beta1.Proposal, error)
 }
 
 func QueryProposal(container, id string) (govtypesv1.Proposal, error) {
+	var out string
+	var err error
+
 	fmt.Println("Querying proposal from", container)
 	args := append([]string{
 		CLI_BINARY_NAME,
 		"query", "gov", "proposal", id,
 	}, QUERY_PARAMS...)
 
-	out, err := LocalnetExecExec(container, args...)
+	// ToDo: refactor
+	if RUN_INSIDE_DOCKER {
+		println("Inside the container")
+		out, err = LocalnetExecExec(container, args...)
+	} else {
+		println("just local run")
+		out, err = ExecDirectWithHome(container, args...)
+	}
+
 	if err != nil {
 		return govtypesv1.Proposal{}, err
 	}

--- a/tests/upgrade/integration/cli/tx.go
+++ b/tests/upgrade/integration/cli/tx.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 
@@ -10,6 +11,9 @@ import (
 )
 
 func Tx(container string, binary string, module, tx, from string, txArgs ...string) (sdk.TxResponse, error) {
+	var output string
+	var err error
+
 	args := []string{
 		binary,
 		"tx",
@@ -26,7 +30,12 @@ func Tx(container string, binary string, module, tx, from string, txArgs ...stri
 	// Other args
 	args = append(args, txArgs...)
 
-	output, err := LocalnetExecExec(container, args...)
+	// ToDo: refactor
+	if RUN_INSIDE_DOCKER {
+		output, err = LocalnetExecExec(container, args...)
+	} else {
+		output, err = ExecDirectWithHome(container, args...)
+	}
 	if err != nil {
 		return sdk.TxResponse{}, err
 	}
@@ -45,6 +54,9 @@ func Tx(container string, binary string, module, tx, from string, txArgs ...stri
 }
 
 func SubmitParamChangeProposal(container string, pathToDir ...string) (sdk.TxResponse, error) {
+	var err error
+	var out string
+
 	fmt.Println("Submitting param change proposal from", container)
 	args := append([]string{
 		CLI_BINARY_NAME,
@@ -52,7 +64,13 @@ func SubmitParamChangeProposal(container string, pathToDir ...string) (sdk.TxRes
 		"--from", OperatorAccounts[container],
 	}, TX_PARAMS...)
 
-	out, err := LocalnetExecExec(container, args...)
+	// ToDo: refactor
+	if RUN_INSIDE_DOCKER {
+		out, err = LocalnetExecExec(container, args...)
+	} else {
+		out, err = ExecDirectWithHome(container, args...)
+	}
+
 	if err != nil {
 		fmt.Println("Error on submitting ParamChangeProposal", err)
 		fmt.Println("Output:", out)
@@ -74,11 +92,20 @@ func SubmitParamChangeProposal(container string, pathToDir ...string) (sdk.TxRes
 }
 
 func SubmitUpgradeProposal(upgradeHeight int64, container string) (sdk.TxResponse, error) {
+	var err error
+	var out string
+	
 	fmt.Println("Submitting upgrade proposal from", container)
+	var upgrade_name = os.Getenv("UPGRADE_NAME")
+	if upgrade_name == "" {
+		upgrade_name = UPGRADE_NAME
+	}
+	fmt.Println("Upgrade name:", upgrade_name)
+
 	args := append([]string{
 		CLI_BINARY_NAME,
 		"tx", "gov", "submit-proposal", "software-upgrade",
-		UPGRADE_NAME,
+		upgrade_name,
 		"--title", "Upgrade Title",
 		"--description", "Upgrade Description",
 		"--upgrade-height", strconv.FormatInt(upgradeHeight, 10),
@@ -86,7 +113,13 @@ func SubmitUpgradeProposal(upgradeHeight int64, container string) (sdk.TxRespons
 		"--from", OperatorAccounts[container],
 	}, TX_PARAMS...)
 
-	out, err := LocalnetExecExec(container, args...)
+	// ToDo: refactor
+	if RUN_INSIDE_DOCKER {
+		out, err = LocalnetExecExec(container, args...)
+	} else {
+		out, err = ExecDirectWithHome(container, args...)
+	}
+
 	if err != nil {
 		return sdk.TxResponse{}, err
 	}
@@ -104,15 +137,24 @@ func SubmitUpgradeProposal(upgradeHeight int64, container string) (sdk.TxRespons
 	return resp, nil
 }
 
-func DepositGov(container string) (sdk.TxResponse, error) {
+func DepositGov(container string, proposal_id string) (sdk.TxResponse, error) {
+	var err error
+	var out string
+
 	fmt.Println("Depositing from", container)
 	args := append([]string{
 		CLI_BINARY_NAME,
-		"tx", "gov", "deposit", "1", DEPOSIT_AMOUNT,
+		"tx", "gov", "deposit", proposal_id, DEPOSIT_AMOUNT,
 		"--from", OperatorAccounts[container],
 	}, TX_PARAMS...)
 
-	out, err := LocalnetExecExec(container, args...)
+	// ToDo: refactor
+	if RUN_INSIDE_DOCKER {
+		out, err = LocalnetExecExec(container, args...)
+	} else {
+		out, err = ExecDirectWithHome(container, args...)
+	}
+
 	if err != nil {
 		return sdk.TxResponse{}, err
 	}
@@ -130,6 +172,9 @@ func DepositGov(container string) (sdk.TxResponse, error) {
 }
 
 func VoteProposal(container, id, option string) (sdk.TxResponse, error) {
+	var err error
+	var out string
+
 	fmt.Println("Voting from", container)
 	args := append([]string{
 		CLI_BINARY_NAME,
@@ -137,7 +182,13 @@ func VoteProposal(container, id, option string) (sdk.TxResponse, error) {
 		"--from", OperatorAccounts[container],
 	}, TX_PARAMS...)
 
-	out, err := LocalnetExecExec(container, args...)
+	// ToDo: refactor
+	if RUN_INSIDE_DOCKER {
+		out, err = LocalnetExecExec(container, args...)
+	} else {
+		out, err = ExecDirectWithHome(container, args...)
+	}
+
 	if err != nil {
 		return sdk.TxResponse{}, err
 	}

--- a/tests/upgrade/integration/pre_send_proposal_test.go
+++ b/tests/upgrade/integration/pre_send_proposal_test.go
@@ -1,0 +1,114 @@
+//go:build upgrade_integration
+
+package integration
+
+import (
+	"fmt"
+	"os"
+	// "path/filepath"
+
+	cli "github.com/cheqd/cheqd-node/tests/upgrade/integration/cli"
+	// didcli "github.com/cheqd/cheqd-node/x/did/client/cli"
+	// didtypesv1 "github.com/cheqd/cheqd-node/x/did/types/v1"
+	// resourcetypesv1 "github.com/cheqd/cheqd-node/x/resource/types/v1"
+	govtypesv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Upgrade - Pre", func() {
+	Context("Before a softare upgrade execution is initiated", func() {
+
+		BeforeEach(func() {
+			cli.RUN_INSIDE_DOCKER = false
+		})
+
+		It("should wait for chain to bootstrap", func() {
+			By("pinging the node status until the dvoting end height is reached")
+			err := cli.WaitForChainHeight(cli.VALIDATOR0, cli.CLI_BINARY_NAME, cli.BOOTSTRAP_HEIGHT, cli.BOOTSTRAP_PERIOD)
+			Expect(err).To(BeNil())
+		})
+
+		var UPGRADE_HEIGHT int64
+		var VOTING_END_HEIGHT int64
+		var proposalID = os.Getenv("PROPOSAL_ID")
+
+		if proposalID == "" {
+			proposalID = "1"
+		}
+
+		fmt.Println("Proposal ID: ", proposalID)
+
+		It("should calculate the upgrade height", func() {
+			By("getting the current block height and calculating the voting end height")
+			var err error
+			UPGRADE_HEIGHT, VOTING_END_HEIGHT, err = cli.CalculateUpgradeHeight(cli.VALIDATOR0, cli.CLI_BINARY_NAME)
+			Expect(err).To(BeNil())
+			fmt.Printf("Upgrade height: %d\n", UPGRADE_HEIGHT)
+			fmt.Printf("Voting end height: %d\n", VOTING_END_HEIGHT)
+		})
+
+		It("should submit a software upgrade proposal", func() {
+			By("sending a SubmitUpgradeProposal transaction from `validator0` container")
+			res, err := cli.SubmitUpgradeProposal(
+				UPGRADE_HEIGHT, 
+				cli.VALIDATOR0)
+			Expect(err).To(BeNil())
+			Expect(res.Code).To(BeEquivalentTo(0))
+		})
+
+		It("should deposit tokens for the software upgrade proposal", func() {
+			By("sending a DepositGov transaction from `validator0` container")
+			res, err := cli.DepositGov(cli.VALIDATOR0, proposalID)
+			Expect(err).To(BeNil())
+			Expect(res.Code).To(BeEquivalentTo(0))
+		})
+
+		It("should vote for the software upgrade proposal from `validator0` container", func() {
+			By("sending a VoteProposal transaction from `validator0` container")
+			res, err := cli.VoteProposal(cli.VALIDATOR0, proposalID, "yes")
+			Expect(err).To(BeNil())
+			Expect(res.Code).To(BeEquivalentTo(0))
+		})
+
+		It("should vote for the software upgrade proposal from `validator1` container", func() {
+			By("sending a VoteProposal transaction from `validator1` container")
+			res, err := cli.VoteProposal(cli.VALIDATOR1, proposalID, "yes")
+			Expect(err).To(BeNil())
+			Expect(res.Code).To(BeEquivalentTo(0))
+		})
+
+		It("should vote for the software upgrade proposal from `validator2` container", func() {
+			By("sending a VoteProposal transaction from `validator2` container")
+			res, err := cli.VoteProposal(cli.VALIDATOR2, proposalID, "yes")
+			Expect(err).To(BeNil())
+			Expect(res.Code).To(BeEquivalentTo(0))
+		})
+
+		It("should vote for the software upgrade proposal from `validator3` container", func() {
+			By("sending a VoteProposal transaction from `validator3` container")
+			res, err := cli.VoteProposal(cli.VALIDATOR3, proposalID, "yes")
+			Expect(err).To(BeNil())
+			Expect(res.Code).To(BeEquivalentTo(0))
+		})
+
+		It("should wait for the voting end height to be reached", func() {
+			By("pinging the node status until the voting end height is reached")
+			err := cli.WaitForChainHeight(cli.VALIDATOR0, cli.CLI_BINARY_NAME, VOTING_END_HEIGHT, cli.VOTING_PERIOD)
+			Expect(err).To(BeNil())
+		})
+
+		It("should query the proposal status to ensure it has passed", func() {
+			By("sending a QueryProposal Msg from `validator0` container")
+			proposal, err := cli.QueryProposalLegacy(cli.VALIDATOR0, proposalID)
+			Expect(err).To(BeNil())
+			Expect(proposal.Status).To(BeEquivalentTo(govtypesv1beta1.StatusPassed))
+		})
+
+		It("should wait for the upgrade height to be reached", func() {
+			By("pinging the node status until the upgrade height is reached")
+			err := cli.WaitForChainHeight(cli.VALIDATOR0, cli.CLI_BINARY_NAME, UPGRADE_HEIGHT, cli.VOTING_PERIOD)
+			Expect(err).To(BeNil())
+		})
+	})
+})

--- a/tests/upgrade/integration/pre_test.go
+++ b/tests/upgrade/integration/pre_test.go
@@ -4,6 +4,7 @@ package integration
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	cli "github.com/cheqd/cheqd-node/tests/upgrade/integration/cli"
@@ -113,6 +114,11 @@ var _ = Describe("Upgrade - Pre", func() {
 
 		var UPGRADE_HEIGHT int64
 		var VOTING_END_HEIGHT int64
+		var proposalID = os.Getenv("PROPOSAL_ID")
+
+		if proposalID == "" {
+			proposalID = "1"
+		}
 
 		It("should calculate the upgrade height", func() {
 			By("getting the current block height and calculating the voting end height")
@@ -132,35 +138,35 @@ var _ = Describe("Upgrade - Pre", func() {
 
 		It("should deposit tokens for the software upgrade proposal", func() {
 			By("sending a DepositGov transaction from `validator0` container")
-			res, err := cli.DepositGov(cli.VALIDATOR0)
+			res, err := cli.DepositGov(cli.VALIDATOR0, proposalID)
 			Expect(err).To(BeNil())
 			Expect(res.Code).To(BeEquivalentTo(0))
 		})
 
 		It("should vote for the software upgrade proposal from `validator0` container", func() {
 			By("sending a VoteProposal transaction from `validator0` container")
-			res, err := cli.VoteProposal(cli.VALIDATOR0, "1", "yes")
+			res, err := cli.VoteProposal(cli.VALIDATOR0, proposalID, "yes")
 			Expect(err).To(BeNil())
 			Expect(res.Code).To(BeEquivalentTo(0))
 		})
 
 		It("should vote for the software upgrade proposal from `validator1` container", func() {
 			By("sending a VoteProposal transaction from `validator1` container")
-			res, err := cli.VoteProposal(cli.VALIDATOR1, "1", "yes")
+			res, err := cli.VoteProposal(cli.VALIDATOR1, proposalID, "yes")
 			Expect(err).To(BeNil())
 			Expect(res.Code).To(BeEquivalentTo(0))
 		})
 
 		It("should vote for the software upgrade proposal from `validator2` container", func() {
 			By("sending a VoteProposal transaction from `validator2` container")
-			res, err := cli.VoteProposal(cli.VALIDATOR2, "1", "yes")
+			res, err := cli.VoteProposal(cli.VALIDATOR2, proposalID, "yes")
 			Expect(err).To(BeNil())
 			Expect(res.Code).To(BeEquivalentTo(0))
 		})
 
 		It("should vote for the software upgrade proposal from `validator3` container", func() {
 			By("sending a VoteProposal transaction from `validator3` container")
-			res, err := cli.VoteProposal(cli.VALIDATOR3, "1", "yes")
+			res, err := cli.VoteProposal(cli.VALIDATOR3, proposalID, "yes")
 			Expect(err).To(BeNil())
 			Expect(res.Code).To(BeEquivalentTo(0))
 		})
@@ -173,7 +179,7 @@ var _ = Describe("Upgrade - Pre", func() {
 
 		It("should query the proposal status to ensure it has passed", func() {
 			By("sending a QueryProposal Msg from `validator0` container")
-			proposal, err := cli.QueryProposalLegacy(cli.VALIDATOR0, "1")
+			proposal, err := cli.QueryProposalLegacy(cli.VALIDATOR0, proposalID)
 			Expect(err).To(BeNil())
 			Expect(proposal.Status).To(BeEquivalentTo(govtypesv1beta1.StatusPassed))
 		})


### PR DESCRIPTION
Environment variables:
- UPGRADE_NAME - uses to change the upgrade name
- PROPOSAL_ID      - proposal id
- CHEQD_NODE_HOME - allows to change the directory with keys. By default it compiles the path from "docker/localnet/network-config" + operator name. Like "docker/localnet/network-config/validator-0". In case of copying keys to "/home/cheqd/.cheqdnode" this value can be set as CHEQD_NODE_HOME.
- DEBUG - in case of setting "DEBUG=true" will print the whole string of command, like "cheqd-noded tx gov vote 2 yes --from operator-3 --gas auto --gas-adjustment 1.8 --gas-prices 25ncheq --keyring-backend test --chain-id cheqd -y --home ../../../docker/localnet/network-config/validator-3". Works for docker and local executions.