### PR TITLE
fix(lint): Ignore non-breaking combine config

### DIFF
--- a/.github/linters/.spectral.yml
+++ b/.github/linters/.spectral.yml
@@ -1,6 +1,0 @@
-formats:
- - oas2
-
-overrides:
-  files:
-    - "**/config.yaml"


### PR DESCRIPTION
- Removes spectral config that validates swagger-combine tool config.
- Non-blocking.