### PR TITLE
fix: Set AppVersion/ProtocolVersion [DEV-2112]

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -259,6 +259,7 @@ func New(
 	)
 	bApp.SetCommitMultiStoreTracer(traceStore)
 	bApp.SetVersion(version.Version)
+	bApp.SetProtocolVersion(ProtocolVersion)
 	bApp.SetInterfaceRegistry(interfaceRegistry)
 
 	keys := sdk.NewKVStoreKeys(

--- a/app/const.go
+++ b/app/const.go
@@ -4,7 +4,9 @@ const (
 	Name = "cheqd-node"
 	Home = ".cheqdnode"
 
-	UpgradeName = "v1"
+	// Set ProtocolVersion to app's major version number
+	ProtocolVersion = 1
+	UpgradeName     = "v1"
 
 	// allowed msg types of ica host
 	authzMsgExec                        = "/cosmos.authz.v1beta1.MsgExec"


### PR DESCRIPTION
This fix gets ABCI info and status endpoints to correctly set app/protocol version to `1`, which is the new major version number.