### PR TITLE
fix: makefile LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ ifeq ($(NO_STRIP),false)
   ldflags += -w -s
 endif
 
-ldflags += $(LD_FLAGS)
+ldflags += $(LDFLAGS)
 ldflags := $(strip $(ldflags))
 
 # set build flags


### PR DESCRIPTION
This allows to build static binary without deps - to be used in Heighliner.

[agouin](https://github.com/agouin) identified `LDFLAGS` was missing in  https://github.com/strangelove-ventures/heighliner/issues/166