### PR TITLE
fix: ibc defi tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -447,3 +447,7 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# ignore mnemonics
+tests/ibc-defi/cheqd_relayer_mnemonic.txt
+tests/ibc-defi/osmo_relayer_mnemonic.txt

--- a/app/app.go
+++ b/app/app.go
@@ -1054,6 +1054,12 @@ func (app *App) RegisterUpgradeHandlers() {
 		upgradeV2.UpgradeName,
 		func(ctx sdk.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 			_, err := ibctmmigrations.PruneExpiredConsensusStates(ctx, app.appCodec, app.IBCKeeper.ClientKeeper)
+
+			// explicitly update the IBC 02-client params, adding the localhost client type
+			params := app.IBCKeeper.ClientKeeper.GetParams(ctx)
+			params.AllowedClients = append(params.AllowedClients, ibcexported.Localhost)
+			app.IBCKeeper.ClientKeeper.SetParams(ctx, params)
+
 			if err != nil {
 				return nil, err
 			}

--- a/app/app.go
+++ b/app/app.go
@@ -1053,8 +1053,10 @@ func (app *App) RegisterUpgradeHandlers() {
 	app.UpgradeKeeper.SetUpgradeHandler(
 		upgradeV2.UpgradeName,
 		func(ctx sdk.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+			// IBC v6 - v7 upgrade
 			_, err := ibctmmigrations.PruneExpiredConsensusStates(ctx, app.appCodec, app.IBCKeeper.ClientKeeper)
 
+			// IBC v7 - v7.3 upgrade
 			// explicitly update the IBC 02-client params, adding the localhost client type
 			params := app.IBCKeeper.ClientKeeper.GetParams(ctx)
 			params.AllowedClients = append(params.AllowedClients, ibcexported.Localhost)

--- a/app/app.go
+++ b/app/app.go
@@ -122,6 +122,7 @@ import (
 	porttypes "github.com/cosmos/ibc-go/v7/modules/core/05-port/types"
 	ibcexported "github.com/cosmos/ibc-go/v7/modules/core/exported"
 	ibckeeper "github.com/cosmos/ibc-go/v7/modules/core/keeper"
+	ibctm "github.com/cosmos/ibc-go/v7/modules/light-clients/07-tendermint"
 	ibctmmigrations "github.com/cosmos/ibc-go/v7/modules/light-clients/07-tendermint/migrations"
 	"github.com/gorilla/mux"
 	"github.com/rakyll/statik/fs"
@@ -157,6 +158,7 @@ var (
 		crisis.AppModuleBasic{},
 		slashing.AppModuleBasic{},
 		ibc.AppModuleBasic{},
+		ibctm.AppModuleBasic{},
 		transfer.AppModuleBasic{},
 		ica.AppModuleBasic{},
 		upgrade.AppModuleBasic{},

--- a/tests/ibc-defi/cheqd/cheqd-init.sh
+++ b/tests/ibc-defi/cheqd/cheqd-init.sh
@@ -24,6 +24,7 @@ sed -i $SED_EXT 's|minimum-gas-prices = ""|minimum-gas-prices = "50ncheq"|g' "$H
 
 # shellcheck disable=SC2086
 sed -i $SED_EXT 's|laddr = "tcp://127.0.0.1:26657"|laddr = "tcp://0.0.0.0:26657"|g' "$HOME/.cheqdnode/config/config.toml"
+sed -i $SED_EXT 's|address = "localhost:9090"|address = "0.0.0.0:9090"|g' "$HOME/.cheqdnode/config/app.toml"
 
 # Genesis
 GENESIS="$HOME/.cheqdnode/config/genesis.json"

--- a/tests/ibc-defi/docker-compose.yaml
+++ b/tests/ibc-defi/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
     entrypoint: tail -f /dev/null
 
   osmosis:
-    image: osmolabs/osmosis:13-alpine
+    image: osmolabs/osmosis:23.0.1-alpine
     ports:
       - "26666:26656" # p2p
       - "26667:26657" # rpc
@@ -23,7 +23,7 @@ services:
     entrypoint: tail -f /dev/null
 
   hermes:
-    image: informalsystems/hermes:1.2.0
+    image: informalsystems/hermes:v1.8.0
     configs:
       - source: hermes-config
         target: /home/hermes/.hermes/config.toml

--- a/tests/ibc-defi/hermes/config.toml
+++ b/tests/ibc-defi/hermes/config.toml
@@ -37,7 +37,7 @@ port = 3001
 id = 'cheqd'
 rpc_addr = 'http://cheqd:26657'
 grpc_addr = 'http://cheqd:9090'
-websocket_addr = 'ws://cheqd:26657/websocket'
+event_source = { mode = 'push', url = 'ws://cheqd:26657/websocket', batch_delay = '500ms' }
 rpc_timeout = '10s'
 account_prefix = 'cheqd'
 key_name = 'cheqd-key'
@@ -58,14 +58,14 @@ trust_threshold = { numerator = '1', denominator = '3' }
 id = 'osmosis'
 rpc_addr = 'http://osmosis:26657'
 grpc_addr = 'http://osmosis:9090'
-websocket_addr = 'ws://osmosis:26657/websocket'
+event_source = { mode = 'push', url = 'ws://osmosis:26657/websocket', batch_delay = '500ms' }
 rpc_timeout = '10s'
 account_prefix = 'osmo'
 key_name = 'osmosis-key'
 store_prefix = 'ibc'
 default_gas = 100000
 max_gas = 400000
-gas_price = { price = 0, denom = 'uosmo' }
+gas_price = { price = 1, denom = 'uosmo' }
 gas_multiplier = 1.3
 max_msg_num = 30
 max_tx_size = 2097152

--- a/tests/ibc-defi/ibc-transfer-test.sh
+++ b/tests/ibc-defi/ibc-transfer-test.sh
@@ -114,9 +114,6 @@ docker compose cp osmo_relayer_mnemonic.txt hermes:/home/hermes
 docker compose exec hermes hermes keys add --chain cheqd --mnemonic-file cheqd_relayer_mnemonic.txt --key-name cheqd-key
 docker compose exec hermes hermes keys add --chain osmosis --mnemonic-file osmo_relayer_mnemonic.txt --key-name osmosis-key
 
-# docker compose exec hermes keys list --chain cheqd
-# docker compose exec hermes keys list --chain osmosis
-
 info "Open channel" # ---
 docker compose exec hermes hermes create channel --a-chain cheqd --b-chain osmosis --a-port transfer --b-port transfer --new-client-connection --yes
 

--- a/tests/ibc-defi/ibc-transfer-test.sh
+++ b/tests/ibc-defi/ibc-transfer-test.sh
@@ -118,7 +118,7 @@ docker compose exec hermes hermes keys add --chain osmosis --mnemonic-file osmo_
 # docker compose exec hermes keys list --chain osmosis
 
 info "Open channel" # ---
-docker compose exec hermes hermes create channel --a-chain cheqd --b-chain osmosis --a-port transfer --b-port transfer --new-client-connection
+docker compose exec hermes hermes create channel --a-chain cheqd --b-chain osmosis --a-port transfer --b-port transfer --new-client-connection --yes
 
 info "Start hermes" # ---
 docker compose exec -d hermes hermes start
@@ -149,7 +149,7 @@ docker compose exec osmosis osmosisd query ibc-transfer denom-trace "$DENOM_CUT"
 info "Transfer osmosis -> cheqd" # ---
 PORT="transfer"
 CHANNEL="channel-0"
-docker compose exec osmosis osmosisd tx ibc-transfer transfer $PORT $CHANNEL "$CHEQD_USER_ADDRESS" 10000000000"${DENOM}" --from osmosis-user --chain-id osmosis --keyring-backend test -y
+docker compose exec osmosis osmosisd tx ibc-transfer transfer $PORT $CHANNEL "$CHEQD_USER_ADDRESS" 10000000000"${DENOM}" --from osmosis-user --chain-id osmosis --fees 500uosmo --keyring-backend test -y
 sleep 30 # Wait for relayer
 
 info "Get balances" # ---

--- a/tests/ibc-defi/ibc-transfer-test.sh
+++ b/tests/ibc-defi/ibc-transfer-test.sh
@@ -53,8 +53,9 @@ docker compose exec -d cheqd cheqd-noded start
 
 info "Running osmosis network"
 docker compose up -d osmosis
-docker compose cp osmosis/osmosis-init.sh osmosis:/home/osmosis/osmosis-init.sh
-docker compose exec osmosis bash /home/osmosis/osmosis-init.sh
+docker compose cp osmosis/osmosis-init.sh osmosis:/osmosis/osmosis-init.sh
+docker compose exec osmosis apk add bash
+docker compose exec osmosis bash /osmosis/osmosis-init.sh
 docker compose exec -d osmosis osmosisd start
 
 info "Waiting for chains"
@@ -78,7 +79,7 @@ CHEQD_RELAYER_MNEMONIC=$(echo "${CHEQD_RELAYER_ACCOUNT}" | jq --raw-output '.mne
 echo "${CHEQD_RELAYER_MNEMONIC}" > cheqd_relayer_mnemonic.txt
 
 info "Send some tokens to it" # ---
-RES=$(docker compose exec cheqd cheqd-noded tx bank send cheqd-user "${CHEQD_RELAYER_ADDRESS}" 1000000000000ncheq --gas-prices 50ncheq --chain-id cheqd -y --keyring-backend test)
+RES=$(docker compose exec cheqd cheqd-noded tx bank send cheqd-user "${CHEQD_RELAYER_ADDRESS}" 500000000000000000ncheq --gas-prices 50ncheq --chain-id cheqd -y --keyring-backend test)
 assert_tx_successful "${RES}"
 
 info "Create relayer user on osmosis" # ---
@@ -90,7 +91,7 @@ OSMOSIS_RELAYER_MNEMONIC=$(echo "${OSMOSIS_RELAYER_ACCOUNT}" | jq --raw-output '
 echo "${OSMOSIS_RELAYER_MNEMONIC}" > osmo_relayer_mnemonic.txt
 
 info "Send some tokens to it" # ---
-RES=$(docker compose exec osmosis osmosisd tx bank send osmosis-user "${OSMOSIS_RELAYER_ADDRESS}" 10000000uosmo --chain-id osmosis -y --keyring-backend test --output json)
+RES=$(docker compose exec osmosis osmosisd tx bank send osmosis-user "${OSMOSIS_RELAYER_ADDRESS}" 1000000000uosmo --fees 500uosmo --chain-id osmosis -y --keyring-backend test --output json)
 assert_tx_successful "${RES}"
 sleep 10 # Wait for state
 
@@ -112,6 +113,9 @@ docker compose cp osmo_relayer_mnemonic.txt hermes:/home/hermes
 # Import keys
 docker compose exec hermes hermes keys add --chain cheqd --mnemonic-file cheqd_relayer_mnemonic.txt --key-name cheqd-key
 docker compose exec hermes hermes keys add --chain osmosis --mnemonic-file osmo_relayer_mnemonic.txt --key-name osmosis-key
+
+# docker compose exec hermes keys list --chain cheqd
+# docker compose exec hermes keys list --chain osmosis
 
 info "Open channel" # ---
 docker compose exec hermes hermes create channel --a-chain cheqd --b-chain osmosis --a-port transfer --b-port transfer --new-client-connection

--- a/tests/ibc-defi/osmosis/osmosis-init.sh
+++ b/tests/ibc-defi/osmosis/osmosis-init.sh
@@ -20,6 +20,7 @@ osmosisd init --chain-id "$CHAIN_ID" testing
 # Config
 sed -i $SED_EXT 's/"stake"/"uosmo"/' "$HOME/.osmosisd/config/genesis.json"
 sed -i $SED_EXT 's|laddr = "tcp://127.0.0.1:26657"|laddr = "tcp://0.0.0.0:26657"|g' "$HOME/.osmosisd/config/config.toml"
+sed -i $SED_EXT 's|address = "localhost:9090"|address = "0.0.0.0:9090"|g' "$HOME/.osmosisd/config/app.toml"
 
 osmosisd keys add osmosis-user --keyring-backend=test
 

--- a/tests/ibc-defi/osmosis/osmosis-init.sh
+++ b/tests/ibc-defi/osmosis/osmosis-init.sh
@@ -17,16 +17,13 @@ CHAIN_ID="osmosis"
 # Node
 osmosisd init --chain-id "$CHAIN_ID" testing
 
-# User
+# Config
+sed -i $SED_EXT 's/"stake"/"uosmo"/' "$HOME/.osmosisd/config/genesis.json"
+sed -i $SED_EXT 's|laddr = "tcp://127.0.0.1:26657"|laddr = "tcp://0.0.0.0:26657"|g' "$HOME/.osmosisd/config/config.toml"
+
 osmosisd keys add osmosis-user --keyring-backend=test
 
 # Genesis
 osmosisd add-genesis-account "$(osmosisd keys show osmosis-user -a --keyring-backend=test)" 2000000000uosmo
 osmosisd gentx osmosis-user 500000000uosmo --keyring-backend=test --chain-id "$CHAIN_ID"
 osmosisd collect-gentxs
-
-jq '.app_state["gov"]["voting_params"]["voting_period"]="10s"' "$HOME/.osmosisd/config/genesis.json" > "$HOME/.osmosisd/config/tmp_genesis.json" && \
-  mv "$HOME/.osmosisd/config/tmp_genesis.json" "$HOME/.osmosisd/config/genesis.json"
-
-# Config
-sed -i $SED_EXT 's|laddr = "tcp://127.0.0.1:26657"|laddr = "tcp://0.0.0.0:26657"|g' "$HOME/.osmosisd/config/config.toml"


### PR DESCRIPTION
use latest code of cheqd : build image from `v047_upgrade`'s sub branch `ap/fix-ibc-tests` 
use latest osmosis docker image: osmolabs/osmosis:23.0.1-alpine
use latest hermes relayer image: informalsystems/hermes:v1.8.0