### PR TITLE
fix: state sync fixes using upgrade handler

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1056,13 +1056,17 @@ func (app *App) RegisterUpgradeHandlers() {
 		func(ctx sdk.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 			// IBC v6 - v7 upgrade
 			_, err := ibctmmigrations.PruneExpiredConsensusStates(ctx, app.appCodec, app.IBCKeeper.ClientKeeper)
-
+			if err != nil {
+				return nil, err
+			}
 			// IBC v7 - v7.3 upgrade
 			// explicitly update the IBC 02-client params, adding the localhost client type
 			params := app.IBCKeeper.ClientKeeper.GetParams(ctx)
 			params.AllowedClients = append(params.AllowedClients, ibcexported.Localhost)
 			app.IBCKeeper.ClientKeeper.SetParams(ctx, params)
 
+			// this should be before updating the version in consensus params
+			baseapp.MigrateParams(ctx, baseAppLegacySS, &app.ConsensusParamsKeeper)
 			consensusParams, err := app.ConsensusParamsKeeper.Get(ctx)
 			if err != nil {
 				return nil, err
@@ -1071,18 +1075,15 @@ func (app *App) RegisterUpgradeHandlers() {
 			// Hack to fix state-sync issue
 			consensusParams.Version = &tmproto.VersionParams{App: 2}
 
-			app.ConsensusParamsKeeper.Set(ctx, consensusParams)
-			updatedVersion, err := app.ConsensusParamsKeeper.Get(ctx)
-			fmt.Println(">>>>>>>>>>>>>>>>>>> new version ", updatedVersion, err)
 			if err != nil {
 				return nil, err
 			}
 			ctx.Logger().Info("Handler for upgrade plan: " + upgradeV2.UpgradeName)
 			// Migrate Tendermint consensus parameters from x/params module to a
 			// dedicated x/consensus module.
-			baseapp.MigrateParams(ctx, baseAppLegacySS, &app.ConsensusParamsKeeper)
-			migrations, err := app.ModuleManager.RunMigrations(ctx, app.Configurator(), fromVM)
 
+			migrations, err := app.ModuleManager.RunMigrations(ctx, app.Configurator(), fromVM)
+			app.ConsensusParamsKeeper.Set(ctx, consensusParams)
 			return migrations, err
 		},
 	)


### PR DESCRIPTION
This fixes the state sync issue while upgrading sdk version. with below error

`snapshot restoration failed: app version mismatch. Expected: 0, got: 2`

> Solution: In upgrade handler, consensus param App version is set to 2 which is required by cometbft ABCI App version check [here](https://github.com/cometbft/cometbft/blob/cce2e5da5b7f54aed1fe6dd36c14404ad941d714/statesync/syncer.go#L493)