### PR TITLE
build(deps): bump forked dependencies to relevant versions

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -23,5 +23,5 @@ require (
 replace (
 	github.com/cosmos/cosmos-sdk => github.com/cheqd/cosmos-sdk v0.50.13-height-mismatch-patched
 
-// github.com/cosmos/iavl => github.com/cheqd/iavl v0.20.1-uneven-heights
+	github.com/cosmos/iavl => github.com/cheqd/iavl v0.19.2-0.20250417102206-84370d5811fb
 )

--- a/go.mod
+++ b/go.mod
@@ -254,7 +254,7 @@ replace (
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.9.1
 
 	// https://github.com/cheqd/fee-abstraction/tree/cheqd/v0.50.x
-	github.com/osmosis-labs/fee-abstraction/v8 => github.com/cheqd/fee-abstraction/v8 v8.0.3-0.20250415073134-32bfc4118457
+	github.com/osmosis-labs/fee-abstraction/v8 => github.com/cheqd/fee-abstraction/v8 v8.0.3-0.20250515095052-ea7c07e5df2d
 
 	// https://github.com/cheqd/feemarket/tree/cheqd/v0.50.x
 	github.com/skip-mev/feemarket => github.com/cheqd/feemarket v1.0.5-0.20250515091338-b2d79e0d3595

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	cosmossdk.io/math v1.5.3
 	cosmossdk.io/tools/confix v0.1.2
 	filippo.io/edwards25519 v1.1.0
-	github.com/cheqd/cheqd-node/api/v2 v2.0.0-00010101000000-000000000000
+	github.com/cheqd/cheqd-node/api/v2 v2.3.5-0.20250514151055-c7d12358336f
 	github.com/cometbft/cometbft v0.38.12
 	github.com/cosmos/cosmos-proto v1.0.0-beta.5
 	github.com/cosmos/cosmos-sdk v0.50.13
@@ -257,7 +257,7 @@ replace (
 	github.com/osmosis-labs/fee-abstraction/v8 => github.com/cheqd/fee-abstraction/v8 v8.0.3-0.20250415073134-32bfc4118457
 
 	// https://github.com/cheqd/feemarket/tree/cheqd/v0.50.x
-	github.com/skip-mev/feemarket => github.com/cheqd/feemarket v1.0.5-0.20250415072337-dc43e8876c3a
+	github.com/skip-mev/feemarket => github.com/cheqd/feemarket v1.0.5-0.20250515091338-b2d79e0d3595
 
 	// replace broken goleveldb
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7

--- a/go.mod
+++ b/go.mod
@@ -242,8 +242,9 @@ replace (
 	// replace cosmos-sdk v0.50.13
 	github.com/cosmos/cosmos-sdk => github.com/cheqd/cosmos-sdk v0.50.13-height-mismatch-patched
 
-	// replace iavl v0.20.1
-	// github.com/cosmos/iavl => github.com/cheqd/iavl v0.20.1-uneven-heights
+	// replace iavl v1.2.2
+	// https://github.com/cheqd/iavl/tree/cheqd-v1.2.2-uneven-heights
+	github.com/cosmos/iavl => github.com/cheqd/iavl v0.19.2-0.20250417102206-84370d5811fb
 
 	// dgrijalva/jwt-go is deprecated and doesn't receive security updates.
 	// TODO: remove it: https://github.com/cosmos/cosmos-sdk/issues/13134

--- a/go.sum
+++ b/go.sum
@@ -307,8 +307,8 @@ github.com/cheqd/cosmos-sdk v0.50.13-height-mismatch-patched h1:Bakt/tLtxobTXCCH
 github.com/cheqd/cosmos-sdk v0.50.13-height-mismatch-patched/go.mod h1:hrWEFMU1eoXqLJeE6VVESpJDQH67FS1nnMrQIjO2daw=
 github.com/cheqd/fee-abstraction/v8 v8.0.3-0.20250415073134-32bfc4118457 h1:YSbckFNzSYOzQltfya3KsyxdvfbpyfgYwwvPpg3rGMo=
 github.com/cheqd/fee-abstraction/v8 v8.0.3-0.20250415073134-32bfc4118457/go.mod h1:9Q+I4KZJT9OVDaweM6/97/UlNgoA8xdLbqfvMtw9HqU=
-github.com/cheqd/feemarket v1.0.5-0.20250415072337-dc43e8876c3a h1:Z1elmp21v8RwNvcD7qB5H+v/TmkJQBsabaNXbJlTKSg=
-github.com/cheqd/feemarket v1.0.5-0.20250415072337-dc43e8876c3a/go.mod h1:OG9KVRiIGv4oW6uQoHmQMoSvZgbpDeWNawB3oBdKw+Y=
+github.com/cheqd/feemarket v1.0.5-0.20250515091338-b2d79e0d3595 h1:jQni4hA31eQdCjU1nPDIQlLIhX16TEZAkaQHO9ze8QQ=
+github.com/cheqd/feemarket v1.0.5-0.20250515091338-b2d79e0d3595/go.mod h1:ypViL3yKw6aM8/yxwUwwqEJKIAPpT8KrvIOxIL+llXU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/logex v1.2.1 h1:XHDu3E6q+gdHgsdTPH6ImJMIp436vR6MPtH8gP05QzM=
 github.com/chzyer/logex v1.2.1/go.mod h1:JLbx6lG2kDbNRFnfkgvh4eRJRPX1QCoOIWomwysCBrQ=

--- a/go.sum
+++ b/go.sum
@@ -305,8 +305,8 @@ github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 h1:qSGYFH7+jGhD
 github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311/go.mod h1:b583jCggY9gE99b6G5LEC39OIiVsWj+R97kbl5odCEk=
 github.com/cheqd/cosmos-sdk v0.50.13-height-mismatch-patched h1:Bakt/tLtxobTXCCHDPfNlMUsuBjPXNgD1zRMOsijhUE=
 github.com/cheqd/cosmos-sdk v0.50.13-height-mismatch-patched/go.mod h1:hrWEFMU1eoXqLJeE6VVESpJDQH67FS1nnMrQIjO2daw=
-github.com/cheqd/fee-abstraction/v8 v8.0.3-0.20250415073134-32bfc4118457 h1:YSbckFNzSYOzQltfya3KsyxdvfbpyfgYwwvPpg3rGMo=
-github.com/cheqd/fee-abstraction/v8 v8.0.3-0.20250415073134-32bfc4118457/go.mod h1:9Q+I4KZJT9OVDaweM6/97/UlNgoA8xdLbqfvMtw9HqU=
+github.com/cheqd/fee-abstraction/v8 v8.0.3-0.20250515095052-ea7c07e5df2d h1:I7tFPoDwwMgb5NapyOBeliGDfaquySR0tWpBXfXCCmw=
+github.com/cheqd/fee-abstraction/v8 v8.0.3-0.20250515095052-ea7c07e5df2d/go.mod h1:jy8u4XfxPuBu+ZLZXJhfYyNto3+Y503n4P6GtMwSCOM=
 github.com/cheqd/feemarket v1.0.5-0.20250515091338-b2d79e0d3595 h1:jQni4hA31eQdCjU1nPDIQlLIhX16TEZAkaQHO9ze8QQ=
 github.com/cheqd/feemarket v1.0.5-0.20250515091338-b2d79e0d3595/go.mod h1:ypViL3yKw6aM8/yxwUwwqEJKIAPpT8KrvIOxIL+llXU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=

--- a/go.sum
+++ b/go.sum
@@ -309,6 +309,8 @@ github.com/cheqd/fee-abstraction/v8 v8.0.3-0.20250515095052-ea7c07e5df2d h1:I7tF
 github.com/cheqd/fee-abstraction/v8 v8.0.3-0.20250515095052-ea7c07e5df2d/go.mod h1:jy8u4XfxPuBu+ZLZXJhfYyNto3+Y503n4P6GtMwSCOM=
 github.com/cheqd/feemarket v1.0.5-0.20250515091338-b2d79e0d3595 h1:jQni4hA31eQdCjU1nPDIQlLIhX16TEZAkaQHO9ze8QQ=
 github.com/cheqd/feemarket v1.0.5-0.20250515091338-b2d79e0d3595/go.mod h1:ypViL3yKw6aM8/yxwUwwqEJKIAPpT8KrvIOxIL+llXU=
+github.com/cheqd/iavl v0.19.2-0.20250417102206-84370d5811fb h1:CkUOzUDYO6lk9R5F2QtXvmPs/qNG/JheDCHEoUT1jMI=
+github.com/cheqd/iavl v0.19.2-0.20250417102206-84370d5811fb/go.mod h1:GiM43q0pB+uG53mLxLDzimxM9l/5N9UuSY3/D0huuVw=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/logex v1.2.1 h1:XHDu3E6q+gdHgsdTPH6ImJMIp436vR6MPtH8gP05QzM=
 github.com/chzyer/logex v1.2.1/go.mod h1:JLbx6lG2kDbNRFnfkgvh4eRJRPX1QCoOIWomwysCBrQ=
@@ -374,8 +376,6 @@ github.com/cosmos/gogogateway v1.2.0/go.mod h1:iQpLkGWxYcnCdz5iAdLcRBSw3h7NXeOkZ
 github.com/cosmos/gogoproto v1.4.2/go.mod h1:cLxOsn1ljAHSV527CHOtaIP91kK6cCrZETRBrkzItWU=
 github.com/cosmos/gogoproto v1.7.0 h1:79USr0oyXAbxg3rspGh/m4SWNyoz/GLaAh0QlCe2fro=
 github.com/cosmos/gogoproto v1.7.0/go.mod h1:yWChEv5IUEYURQasfyBW5ffkMHR/90hiHgbNgrtp4j0=
-github.com/cosmos/iavl v1.2.2 h1:qHhKW3I70w+04g5KdsdVSHRbFLgt3yY3qTMd4Xa4rC8=
-github.com/cosmos/iavl v1.2.2/go.mod h1:GiM43q0pB+uG53mLxLDzimxM9l/5N9UuSY3/D0huuVw=
 github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v8 v8.0.0 h1:PqaYuNJDpeqisP3Td5djrvFhuVMnOIWFJeqMJuZPRas=
 github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v8 v8.0.0/go.mod h1:82hPO/tRawbuFad2gPwChvpZ0JEIoNi91LwVneAYCeM=
 github.com/cosmos/ibc-apps/modules/async-icq/v8 v8.0.1-0.20240820212149-6a9e98a8be6e h1:vH4wwXwlS4MWaRzCWB4Q3BzuN1v5bk/vIl46WOcOeS0=

--- a/go.work.sum
+++ b/go.work.sum
@@ -171,8 +171,8 @@ github.com/ccojocar/zxcvbn-go v1.0.2/go.mod h1:g1qkXtUSvHP8lhHp5GrSmTz6uWALGRMQd
 github.com/census-instrumentation/opencensus-proto v0.4.1/go.mod h1:4T9NM4+4Vw91VeyqjLS6ao50K5bOcLKN6Q42XnYaRYw=
 github.com/charithe/durationcheck v0.0.10/go.mod h1:bCWXb7gYRysD1CU3C+u4ceO49LoGOY1C1L6uouGNreQ=
 github.com/chavacava/garif v0.1.0/go.mod h1:XMyYCkEL58DF0oyW4qDjjnPWONs2HBqYKI+UIPD+Gww=
-github.com/cheqd/fee-abstraction/v8 v8.0.3-0.20250515095052-ea7c07e5df2d h1:I7tFPoDwwMgb5NapyOBeliGDfaquySR0tWpBXfXCCmw=
-github.com/cheqd/fee-abstraction/v8 v8.0.3-0.20250515095052-ea7c07e5df2d/go.mod h1:jy8u4XfxPuBu+ZLZXJhfYyNto3+Y503n4P6GtMwSCOM=
+github.com/cheqd/iavl v0.19.2-0.20250417102206-84370d5811fb h1:CkUOzUDYO6lk9R5F2QtXvmPs/qNG/JheDCHEoUT1jMI=
+github.com/cheqd/iavl v0.19.2-0.20250417102206-84370d5811fb/go.mod h1:GiM43q0pB+uG53mLxLDzimxM9l/5N9UuSY3/D0huuVw=
 github.com/chigopher/pathlib v0.19.1/go.mod h1:tzC1dZLW8o33UQpWkNkhvPwL5n4yyFRFm/jL1YGWFvY=
 github.com/ckaznocha/intrange v0.1.2/go.mod h1:RWffCw/vKBwHeOEwWdCikAtY0q4gGt8VhJZEEA5n+RE=
 github.com/clbanning/mxj v1.8.4/go.mod h1:BVjHeAH+rl9rs6f+QIpeRl0tfu10SXn1pUSa5PVGJng=

--- a/go.work.sum
+++ b/go.work.sum
@@ -171,8 +171,8 @@ github.com/ccojocar/zxcvbn-go v1.0.2/go.mod h1:g1qkXtUSvHP8lhHp5GrSmTz6uWALGRMQd
 github.com/census-instrumentation/opencensus-proto v0.4.1/go.mod h1:4T9NM4+4Vw91VeyqjLS6ao50K5bOcLKN6Q42XnYaRYw=
 github.com/charithe/durationcheck v0.0.10/go.mod h1:bCWXb7gYRysD1CU3C+u4ceO49LoGOY1C1L6uouGNreQ=
 github.com/chavacava/garif v0.1.0/go.mod h1:XMyYCkEL58DF0oyW4qDjjnPWONs2HBqYKI+UIPD+Gww=
-github.com/cheqd/feemarket v1.0.5-0.20250515091338-b2d79e0d3595 h1:jQni4hA31eQdCjU1nPDIQlLIhX16TEZAkaQHO9ze8QQ=
-github.com/cheqd/feemarket v1.0.5-0.20250515091338-b2d79e0d3595/go.mod h1:ypViL3yKw6aM8/yxwUwwqEJKIAPpT8KrvIOxIL+llXU=
+github.com/cheqd/fee-abstraction/v8 v8.0.3-0.20250515095052-ea7c07e5df2d h1:I7tFPoDwwMgb5NapyOBeliGDfaquySR0tWpBXfXCCmw=
+github.com/cheqd/fee-abstraction/v8 v8.0.3-0.20250515095052-ea7c07e5df2d/go.mod h1:jy8u4XfxPuBu+ZLZXJhfYyNto3+Y503n4P6GtMwSCOM=
 github.com/chigopher/pathlib v0.19.1/go.mod h1:tzC1dZLW8o33UQpWkNkhvPwL5n4yyFRFm/jL1YGWFvY=
 github.com/ckaznocha/intrange v0.1.2/go.mod h1:RWffCw/vKBwHeOEwWdCikAtY0q4gGt8VhJZEEA5n+RE=
 github.com/clbanning/mxj v1.8.4/go.mod h1:BVjHeAH+rl9rs6f+QIpeRl0tfu10SXn1pUSa5PVGJng=

--- a/go.work.sum
+++ b/go.work.sum
@@ -171,6 +171,8 @@ github.com/ccojocar/zxcvbn-go v1.0.2/go.mod h1:g1qkXtUSvHP8lhHp5GrSmTz6uWALGRMQd
 github.com/census-instrumentation/opencensus-proto v0.4.1/go.mod h1:4T9NM4+4Vw91VeyqjLS6ao50K5bOcLKN6Q42XnYaRYw=
 github.com/charithe/durationcheck v0.0.10/go.mod h1:bCWXb7gYRysD1CU3C+u4ceO49LoGOY1C1L6uouGNreQ=
 github.com/chavacava/garif v0.1.0/go.mod h1:XMyYCkEL58DF0oyW4qDjjnPWONs2HBqYKI+UIPD+Gww=
+github.com/cheqd/feemarket v1.0.5-0.20250515091338-b2d79e0d3595 h1:jQni4hA31eQdCjU1nPDIQlLIhX16TEZAkaQHO9ze8QQ=
+github.com/cheqd/feemarket v1.0.5-0.20250515091338-b2d79e0d3595/go.mod h1:ypViL3yKw6aM8/yxwUwwqEJKIAPpT8KrvIOxIL+llXU=
 github.com/chigopher/pathlib v0.19.1/go.mod h1:tzC1dZLW8o33UQpWkNkhvPwL5n4yyFRFm/jL1YGWFvY=
 github.com/ckaznocha/intrange v0.1.2/go.mod h1:RWffCw/vKBwHeOEwWdCikAtY0q4gGt8VhJZEEA5n+RE=
 github.com/clbanning/mxj v1.8.4/go.mod h1:BVjHeAH+rl9rs6f+QIpeRl0tfu10SXn1pUSa5PVGJng=
@@ -323,10 +325,6 @@ github.com/nishanths/exhaustive v0.12.0/go.mod h1:mEZ95wPIZW+x8kC4TgC+9YCUgiST7e
 github.com/nishanths/predeclared v0.2.2/go.mod h1:RROzoN6TnGQupbC+lqggsOlcgysk3LMK/HI84Mp280c=
 github.com/nunnatsa/ginkgolinter v0.16.2/go.mod h1:4tWRinDN1FeJgU+iJANW/kz7xKN5nYRAOfJDQUS9dOQ=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
-github.com/onsi/ginkgo/v2 v2.22.2 h1:/3X8Panh8/WwhU/3Ssa6rCKqPLuAkVY2I0RoyDLySlU=
-github.com/onsi/ginkgo/v2 v2.22.2/go.mod h1:oeMosUL+8LtarXBHu/c0bx2D/K9zyQ6uX3cTyztHwsk=
-github.com/onsi/gomega v1.36.2 h1:koNYke6TVk6ZmnyHrCXba/T/MoLBXFjeC1PtvYgw0A8=
-github.com/onsi/gomega v1.36.2/go.mod h1:DdwyADRjrc825LhMEkD76cHR5+pUnjhUN8GlHlRPHzY=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/openzipkin/zipkin-go v0.2.5/go.mod h1:KpXfKdgRDnnhsxw4pNIH9Md5lyFqKUa4YDFlwRYAMyE=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=


### PR DESCRIPTION
IAVL patch: https://github.com/cheqd/iavl/tree/cheqd-v1.2.2-uneven-heights