### PR TITLE
refactor: use slices.ContainsFunc to simplify code

### DIFF
--- a/ante/tx_msg_filters.go
+++ b/ante/tx_msg_filters.go
@@ -1,6 +1,7 @@
 package ante
 
 import (
+	"slices"
 	"strings"
 
 	sdkmath "cosmossdk.io/math"
@@ -155,11 +156,5 @@ func IsTaxableTx(ctx sdk.Context, didKeeper DidKeeper, resourceKeeper ResourceKe
 
 func IsTaxableTxLite(tx sdk.Tx) bool {
 	msgs := tx.GetMsgs()
-	for _, msg := range msgs {
-		if GetTaxableMsg(msg) {
-			return true
-		}
-	}
-
-	return false
+	return slices.ContainsFunc(msgs, GetTaxableMsg)
 }


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.0#ContainsFunc) added in the go1.21 standard library, which can make the code more concise and easy to read.