### PR TITLE
fix: Remove license and readme files from goreleaser build [DEV-5671]

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -79,6 +79,8 @@ archives:
     format: tar.gz
     wrap_in_directory: false
     name_template: "{{ .Binary }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    files:
+      - none*
 
 checksum:
   algorithm: sha256


### PR DESCRIPTION
This PR adds an explicit deny for all files in the goreleaser archive builds as LICENSE and README files are still being included in the tar archives. Reference: https://github.com/cosmos/gaia/blob/a8b6673a9662784f14459ade088d8675e2cb5c23/.goreleaser.yml#L148